### PR TITLE
testtools recently upgraded to 1.7.1, which is causing our test suite to crash and burn when writing results

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 junitxml
 python-subunit
 selenium==2.44.0
-testtools
+testtools==1.6.1


### PR DESCRIPTION
here's the error i'm seeing locally when running the suite with testtools 1.7.1. pinning to 1.6.1 fixes this.

```
  File "/usr/local/bin/sst-run", line 9, in <module>
    load_entry_point('sst==0.2.5dev', 'console_scripts', 'sst-run')()
  File "/usr/local/lib/python2.7/dist-packages/sst-0.2.5dev-py2.7.egg/sst/scripts/run.py", line 71, in main
    excludes=cmd_opts.excludes
  File "/usr/local/lib/python2.7/dist-packages/sst-0.2.5dev-py2.7.egg/sst/runtests.py", line 115, in runtests
    suite.run(result)
  File "/usr/lib/python2.7/unittest/suite.py", line 108, in run
    test(result)
  File "/usr/local/lib/python2.7/dist-packages/unittest2-1.0.0-py2.7.egg/unittest2/case.py", line 649, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/testcase.py", line 606, in run
    return run_test.run(result)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/runtest.py", line 80, in run
    return self._run_one(actual_result)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/runtest.py", line 94, in _run_one
    return self._run_prepared_result(ExtendedToOriginalDecorator(result))
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/runtest.py", line 121, in _run_prepared_result
    result.stopTest(self.case)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/testresult/real.py", line 1271, in stopTest
    return self.decorated.stopTest(test)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/testresult/real.py", line 835, in stopTest
    return self._dispatch('stopTest', test)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/testresult/real.py", line 811, in _dispatch
    for result in self._results)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/testresult/real.py", line 811, in <genexpr>
    for result in self._results)
  File "/usr/local/lib/python2.7/dist-packages/testtools-1.7.1-py2.7.egg/testtools/testresult/real.py", line 1271, in stopTest
    return self.decorated.stopTest(test)
  File "/usr/local/lib/python2.7/dist-packages/sst-0.2.5dev-py2.7.egg/sst/results.py", line 41, in stopTest
    % self._delta_to_float(elapsed_time))
TypeError: _delta_to_float() takes exactly 3 arguments (2 given)
```

cc @Bassoon08 @cdangg @rtabor 