### PR TITLE
Create poll_for_not_stale action

### DIFF
--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -1816,3 +1816,25 @@ def poll_for_exists(locator, wait=10, frequency=1):
         return elem
     except:
         _raise("Element not found with locator {}.".format(locator))
+
+def poll_for_not_stale(id_or_elem, wait=10, frequency=1):
+    """Use WebDriverWait with a custom condition with exception handling for
+    StaleElementReferenceException to poll for an element to become not stale.
+    :argument id_or_elem: The identifier of the element, or its element object.
+    :argument wait: The amount of seconds to wait before throwing a
+    TimeoutException.
+    :argument frequency: The amount of seconds between each poll.
+
+    """
+    elem = _get_elem(id_or_elem)
+    driver = _test.browser
+    def wait_for_not_stale(driver):
+        try:
+            elem.is_displayed()
+            return True
+        except StaleElementReferenceException:
+            return False
+
+    msg = 'Timeout waiting for element to not be stale.'
+    (WebDriverWait(driver, wait, poll_frequency=frequency)
+                   .until(wait_for_not_stale, msg))

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -1824,6 +1824,7 @@ def poll_for_not_stale(id_or_elem, wait=10, frequency=1):
     :argument wait: The amount of seconds to wait before throwing a
     TimeoutException.
     :argument frequency: The amount of seconds between each poll.
+    :return: The WebElement object that was polled for.
 
     """
     elem = _get_elem(id_or_elem)
@@ -1838,3 +1839,5 @@ def poll_for_not_stale(id_or_elem, wait=10, frequency=1):
     msg = 'Timeout waiting for element to not be stale.'
     (WebDriverWait(driver, wait, poll_frequency=frequency)
                    .until(wait_for_not_stale, msg))
+
+    return elem

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -84,12 +84,12 @@ __all__ = [
     'get_elements', 'get_elements_by_css', 'get_elements_by_xpath',
     'get_link_url', 'get_page_source', 'get_text', 'get_wait_timeout',
     'get_window_size', 'go_back', 'go_to', 'hover_over_element',
-    'poll_for_exists', 'poll_for_visibility', 'refresh', 'reset_base_url',
-    'retry_on_exception', 'run_test', 'save_page_source', 'set_base_url',
-    'set_checkbox_value', 'set_dropdown_value', 'set_radio_value',
-    'set_wait_timeout', 'set_window_size', 'simulate_keys', 'skip', 'sleep',
-    'switch_to_frame', 'switch_to_window', 'take_screenshot', 'toggle_checkbox',
-    'wait_for', 'wait_for_and_refresh', 'write_textfield'
+    'poll_for_exists', 'poll_for_not_stale', 'poll_for_visibility', 'refresh',
+    'reset_base_url', 'retry_on_exception', 'run_test', 'save_page_source',
+    'set_base_url', 'set_checkbox_value', 'set_dropdown_value',
+    'set_radio_value', 'set_wait_timeout', 'set_window_size', 'simulate_keys',
+    'skip', 'sleep', 'switch_to_frame', 'switch_to_window', 'take_screenshot',
+    'toggle_checkbox', 'wait_for', 'wait_for_and_refresh', 'write_textfield'
 ]
 
 


### PR DESCRIPTION
This action can be used when changes are happening on a page, and you expect to see a `StaleElementReferenceException` until the page has finished loading. It uses `WebDriverWait` with a custom condition to poll for an element to become not stale.

@rmdaggett @cdangg @rtabor 