### PR TITLE
Set Firefox browser.download preferences

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -195,6 +195,7 @@ class FirefoxFactory(BrowserFactory):
     def setup_for_test(self, test):
         profile = webdriver.FirefoxProfile()
         profile.set_preference('intl.accept_languages', 'en')
+        profile.set_preference('browser.download.folderList', 1)
         profile.set_preference('browser.download.manager.showWhenStarting', False)
         profile.set_preference('browser.download.manager.useWindow', False)
         if test.assume_trusted_cert_issuer:

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -196,6 +196,7 @@ class FirefoxFactory(BrowserFactory):
         profile = webdriver.FirefoxProfile()
         profile.set_preference('intl.accept_languages', 'en')
         profile.set_preference('browser.download.manager.showWhenStarting', False)
+        profile.set_preference('browser.download.manager.useWindow', False)
         if test.assume_trusted_cert_issuer:
             profile.set_preference('webdriver_assume_untrusted_issuer', False)
             profile.set_preference(

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -195,6 +195,7 @@ class FirefoxFactory(BrowserFactory):
     def setup_for_test(self, test):
         profile = webdriver.FirefoxProfile()
         profile.set_preference('intl.accept_languages', 'en')
+        profile.set_preference('browser.download.manager.showWhenStarting', False)
         if test.assume_trusted_cert_issuer:
             profile.set_preference('webdriver_assume_untrusted_issuer', False)
             profile.set_preference(

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -198,6 +198,7 @@ class FirefoxFactory(BrowserFactory):
         profile.set_preference('browser.download.folderList', 1)
         profile.set_preference('browser.download.manager.showWhenStarting', False)
         profile.set_preference('browser.download.manager.useWindow', False)
+        profile.set_preference('browser.helperApps.neverAsk.saveToDisk', 'text/csv')
         if test.assume_trusted_cert_issuer:
             profile.set_preference('webdriver_assume_untrusted_issuer', False)
             profile.set_preference(


### PR DESCRIPTION
Setting these preferences makes Firefox handle downloads in the same way that Chrome does by default. This means any tests that download a file which are failing in Firefox will work now without needing any other updates. I tested this in a local debug container and download tests are passing.

@rmdaggett @rtabor @rleibovitz89 