### PR TITLE
disable firefox reader view

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -210,6 +210,7 @@ class FirefoxFactory(BrowserFactory):
         profile.set_preference('browser.download.manager.showWhenStarting', False)
         profile.set_preference('browser.download.manager.useWindow', False)
         profile.set_preference('browser.helperApps.neverAsk.saveToDisk', 'text/csv')
+        profile.set_preference('reader.parse-on-load.enabled', False)
         if test.assume_trusted_cert_issuer:
             profile.set_preference('webdriver_assume_untrusted_issuer', False)
             profile.set_preference(


### PR DESCRIPTION
disable the reader view popup that is shown whenever firefox starts. this causes ElementNotVisible exceptions for tests which have to interact with elements that are behind this popup. this is causing a failure in one of our tests (`actor_page_snapshot_132`).

https://support.mozilla.org/en-US/questions/1065043

cc @Bassoon08 @rtabor @rleibovitz89 @nicolenglish 