### PR TITLE
Rd use setup for test when setting capabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 junitxml
 python-subunit
-selenium==2.46.0
+selenium==2.47.1
 testtools==1.6.1

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -84,8 +84,7 @@ class ChromeFactory(BrowserFactory):
 
     webdriver_class = webdriver.Chrome
 
-    def __init__(self):
-        (ChromeFactory, self).__init__()
+    def setup_for_test(self, test):
         chrome_options = Options()
         chrome_options.add_argument("test-type")
         self.capabilities = chrome_options.to_capabilities()


### PR DESCRIPTION
This should fix the hanging issue I've been seeing occasionally when running the tests in Chrome. It seems there's a race condition that can occur where we're setting the capabilities for the browser too early. This does not happen in when running the tests in Firefox. Upon reviewing `browsers.py` I discovered we should be setting browser capabilities by overriding the `setup_for_test` method in the browser daughter classes. After making this change I no longer encountered the hanging issues when running the suite.

Also update to use the newest selenium.

cc @Bassoon08 @rtabor @rleibovitz89 @nicolenglish 