### PR TITLE
fix chromedriver not starting

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -87,12 +87,12 @@ class ChromeFactory(BrowserFactory):
     def setup_for_test(self, test):
         chrome_options = Options()
         chrome_options.add_argument("test-type")
+        chrome_options.add_argument("disable-gpu")
         self.capabilities = chrome_options.to_capabilities()
+        logger.debug("Chrome capabilities: {}".format(self.capabilities))
 
     def browser(self):
-        logger.debug("Chrome capabilities: {}".format(self.capabilities))
         return self.webdriver_class(desired_capabilities=self.capabilities)
-
 
 # MISSINGTEST: Exercise this class (requires windows) -- vila 2013-04-11
 class IeFactory(BrowserFactory):


### PR DESCRIPTION
use disable-gpu flag when starting chrome to disable gpu hardware acceleration. chromedriver logs were showing GPU related errors just before crashing which seem to prevent the browser from starting again. disabling gpu acceleration has cleared up these messages and ive not seen the issue again.

cc @Bassoon08 @rtabor @rleibovitz89 @nicolenglish 