### PR TITLE
rd set firefox response timeout

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -210,6 +210,7 @@ class FirefoxFactory(BrowserFactory):
         profile.set_preference('browser.download.manager.useWindow', False)
         profile.set_preference('browser.helperApps.neverAsk.saveToDisk', 'text/csv')
         profile.set_preference('reader.parse-on-load.enabled', False)
+        profile.set_preference('network.http.response.timeout', 60)
         if test.assume_trusted_cert_issuer:
             profile.set_preference('webdriver_assume_untrusted_issuer', False)
             profile.set_preference(


### PR DESCRIPTION
firefox by default waits a very long time for http timeouts which has caused extremely long runs in cases where certain scripts that run our pages never load (looking at you twitter, facebook). set the default timeout to 60 seconds

cc @Bassoon08 @rtabor @rleibovitz89 @nicolenglish 