### PR TITLE
add 'tel' to textfield tuple

### DIFF
--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -519,7 +519,7 @@ def simulate_keys(id_or_elem, key_to_press):
 
 _textfields = (
     'text', 'password', 'textarea', 'email',
-    'url', 'search', 'number', 'file')
+    'url', 'search', 'number', 'file', 'tel')
 
 
 def assert_textfield(id_or_elem):


### PR DESCRIPTION
adding tel to the list of textfield types, to work with the textfields for braintree hosted fields. without this our tests that use `write_textfield` will fail when trying to write to the braintree fields.

@Bassoon08 @rtabor @rleibovitz89 @nicolenglish 