### PR TITLE
remove disable gpu flag

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -87,7 +87,6 @@ class ChromeFactory(BrowserFactory):
     def setup_for_test(self, test):
         chrome_options = Options()
         chrome_options.add_argument("test-type")
-        chrome_options.add_argument("disable-gpu")
         self.capabilities = chrome_options.to_capabilities()
         logger.debug("Chrome capabilities: {}".format(self.capabilities))
 


### PR DESCRIPTION
this doesnt seem to alleviate the timeout issue we see on jenkins, and just causes tests to run slower locally. removing

@DramaFever/qa 