### PR TITLE
Allow tests called with sst-run to keep the .py extension

### DIFF
--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -162,7 +162,7 @@ class SSTScriptTestCase(SSTTestCase):
         self.script_path = os.path.join(self.script_dir, self.script_name)
 
         # pythonify the script path into a python path
-        test_id = self.script_path.replace('.py', '')
+        test_id = self.script_path
         if test_id.startswith('./'):
             test_id = test_id[2:]
         self.id = lambda: '%s' % (test_id.replace(os.sep, '.'))


### PR DESCRIPTION
Now we can use tab complete on a filename without manually deleting the `.py` extension (and running tests without the extension will still work, just like it does now). Try it out:

```
cd $DFHOME/testing/home_page_tests/
sst-run home_page_ads_734.py
```

Please feel free to test this using different arguments with `sst-run` and in different test directories to make sure everything is still working.

@DramaFever/qa 