### PR TITLE
Remove unsupported method call & increase max tries

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -170,12 +170,15 @@ class FirefoxBinary(firefox_binary.FirefoxBinary):
                 # Browser has exited
                 raise selenium_exceptions.WebDriverException(
                     "The browser appears to have exited "
-                    "before we could connect.")
+                    "before we could connect. If you specified a log_file in "
+                    "the FirefoxBinary constructor, check it for details.")
             time.sleep(sleep_for)
         if not connectable:
             self.kill()
             raise selenium_exceptions.WebDriverException(
-                'Cannot connect to the selenium extension.')
+                "Cannot connect to the selenium extension. If you specified a "
+                "log_file in the FirefoxBinary constructor, check it for "
+                "details.")
         return connectable
 
 

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -158,7 +158,7 @@ class FirefoxBinary(firefox_binary.FirefoxBinary):
         firefox).
         """
         connectable = False
-        max_tries = 6
+        max_tries = 10
         sleep_for = 1
         for count in range(1, max_tries):
             connectable = utils.is_connectable(self.profile.port)
@@ -170,14 +170,12 @@ class FirefoxBinary(firefox_binary.FirefoxBinary):
                 # Browser has exited
                 raise selenium_exceptions.WebDriverException(
                     "The browser appears to have exited "
-                    "before we could connect. The output was: %s" %
-                    self._get_firefox_output())
+                    "before we could connect.")
             time.sleep(sleep_for)
         if not connectable:
             self.kill()
             raise selenium_exceptions.WebDriverException(
-                'Cannot connect to the selenium extension, Firefox output: %s'
-                % (self._get_firefox_output(),))
+                'Cannot connect to the selenium extension.')
         return connectable
 
 


### PR DESCRIPTION
the `_get_firefox_output` method was removed from selenium 2.44 and will throw an an AttributeError exception in the FirefoxBinary class if this line is hit, so remove the unsupported method call and increase the maximum number of tries to spawn the FF process

see https://github.com/SeleniumHQ/selenium/blob/master/py/selenium/webdriver/firefox/firefox_binary.py#L92

@DramaFever/qa 