### PR TITLE
accept and ignore arguments to our overridden method

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -147,7 +147,7 @@ class FirefoxBinary(firefox_binary.FirefoxBinary):
             command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             env=self._firefox_env)
 
-    def _wait_until_connectable(self):
+    def _wait_until_connectable(self, **kwargs):
         """Blocks until the extension is connectable in the firefox.
 
         The base class implements this by checking utils.is_connectable() every


### PR DESCRIPTION
FirefoxBinary's base class now passes timeout to _wait_until_connectable, which isnt used in our overridden version. fixes `TypeError: _wait_until_connectable() got an unexpected keyword argument 'timeout'` when running with selenium > 2.50

@DramaFever/qa 