### PR TITLE
include browsermob binary in egg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include docs *.rst *.py *.png *.css favicon.ico README
 recursive-include src/testproject *.py *.html *.js *.css
 recursive-include src/sst/selftests *.py *.csv
 recursive-include src/sst/tests *.py
+recursive-include src/sst/browsermob-proxy-2.1.2 *

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,8 +41,9 @@ SST consists of:
  * selectable browsers
  * headless (xvfb) mode
  * screenshots on errors
+ * optionally run tests behind proxy
 
-Test output is displayed to the console and optionally saved as 
+Test output is displayed to the console and optionally saved as
 JUnit-compatible XML for compatibility with CI systems.
 
 
@@ -142,6 +143,8 @@ Options::
     -x                        run browser in headless xserver (Xvfb)
     -c CONCURRENCY            concurrency (number of procs)
     --concurrency=CONCURRENCY concurrency (number of procs)
+    -o RESULTS_DIRECTORY      directory where ressults should be stored
+    -p                        run tests with Browsermob Proxy enabled
 
 
 --------------------
@@ -248,7 +251,7 @@ The following commands will therefore run various selections of tests:
 
 * The whole test suite::
 
-    sst-run 
+    sst-run
 
   when invoked at the root of the test tree.
 
@@ -363,7 +366,7 @@ information::
     $ ./ci.sh --bootstrap
     $ source ENV/bin/activate
     (ENV)$ ./sst-run -d examples
-    
+
 * (optional) Install test dependencies and run SST's internal unit tests::
 
     (ENV)$ pip install mock nose pep8

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ params = dict(
     version=__version__,
     packages=PACKAGES,
     package_dir={'': 'src', },
+    package_data={'browsermob-proxy-2.1.2': ['browsermob-proxy-2.1.2/*']},
+    include_package_data=True,
     install_requires=REQUIREMENTS,
 
     # metadata for upload to PyPI


### PR DESCRIPTION
right now when `setup.py` runs it is not including the browsermob-proxy binaries that are needed when the proxy option is sent to the runner. this PR is to include the `browsermob-proxy-2.1.2` dir in the resulting egg when running `python setup.py install`.

@DramaFever/qa 