### PR TITLE
Rd sauce stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-subunit
 selenium==2.53.0
 testtools==1.8.0
 browsermob-proxy==0.7.1
+sauceclient==0.2.1

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -23,6 +23,8 @@ import shutil
 import subprocess
 import time
 
+from sst.remote_capabilities import SauceLabs, BrowserStack
+
 from selenium import webdriver
 from selenium.common import exceptions as selenium_exceptions
 from selenium.webdriver.common import utils
@@ -71,11 +73,16 @@ class RemoteBrowserFactory(BrowserFactory):
 
     def __init__(self, capabilities, remote_url):
         super(RemoteBrowserFactory, self).__init__()
-        self.capabilities = capabilities
+        if 'saucelabs' in remote_url:
+            self.capabilities = SauceLabs.capabilities
+        elif 'browserstack' in remote_url:
+            self.capabilities = BrowserStack.capabilities
+        else:
+            self.capabilities = capabilities
         self.remote_url = remote_url
 
     def browser(self):
-        return self.webdriver_class(self.capabilities, self.remote_url)
+        return self.webdriver_class(self.remote_url, self.capabilities)
 
 
 # MISSINGTEST: Exercise this class -- vila 2013-04-11

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -75,11 +75,15 @@ class RemoteBrowserFactory(BrowserFactory):
         super(RemoteBrowserFactory, self).__init__()
         if 'saucelabs' in remote_url:
             self.capabilities = SauceLabs.capabilities
+            self.remote_url = SauceLabs.URL
+            logger.debug('Connecting to SauceLabs instance: {}'.format(self.remote_url))
         elif 'browserstack' in remote_url:
             self.capabilities = BrowserStack.capabilities
+            self.remote_url = BrowserStack.URL
+            logger.debug('Connecting to BrowserStack instance: {}'.format(self.remote_url))
         else:
             self.capabilities = capabilities
-        self.remote_url = remote_url
+            self.remote_url = remote_url
 
     def browser(self):
         return self.webdriver_class(self.remote_url, self.capabilities)

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -44,6 +44,7 @@ class BrowserFactory(object):
     """
 
     webdriver_class = None
+    remote_client = None
 
     def __init__(self):
         super(BrowserFactory, self).__init__()
@@ -70,7 +71,6 @@ class BrowserFactory(object):
 class RemoteBrowserFactory(BrowserFactory):
 
     webdriver_class = webdriver.Remote
-    remote_client = None
 
     def __init__(self, capabilities, remote_url):
         super(RemoteBrowserFactory, self).__init__()

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -75,15 +75,27 @@ class RemoteBrowserFactory(BrowserFactory):
     def __init__(self, capabilities, remote_url):
         super(RemoteBrowserFactory, self).__init__()
         if 'saucelabs' in remote_url:
-            self.remote_client = SauceLabs()
-            self.capabilities = SauceLabs.capabilities
-            self.remote_url = SauceLabs.URL
-            logger.debug('Connecting to SauceLabs instance: {}'.format(self.remote_url))
+            from sst import runtests
+            creds = runtests.set_client_credentials('saucelabs')
+            try:
+                self.remote_client = SauceLabs(creds.USERNAME,
+                                               creds.ACCESS_KEY,
+                                               creds.URL)
+                self.capabilities = creds.CAPABILITIES
+                self.remote_url = self.remote_client.URL
+                logger.debug('Connecting to SauceLabs instance: {}'
+                             .format(self.remote_url))
+            except:
+                raise Exception('Please create a sauce_config.py module in '
+                                'your test directory with your SauceLabs '
+                                'USERNAME, ACCESS_KEY, URL, '
+                                'and CAPABILITIES set.')
         elif 'browserstack' in remote_url:
             self.remote_client = BrowserStack()
             self.capabilities = BrowserStack.capabilities
             self.remote_url = BrowserStack.URL
-            logger.debug('Connecting to BrowserStack instance: {}'.format(self.remote_url))
+            logger.debug('Connecting to BrowserStack instance: {}'
+                         .format(self.remote_url))
         else:
             self.capabilities = capabilities
             self.remote_url = remote_url

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -70,14 +70,17 @@ class BrowserFactory(object):
 class RemoteBrowserFactory(BrowserFactory):
 
     webdriver_class = webdriver.Remote
+    remote_client = None
 
     def __init__(self, capabilities, remote_url):
         super(RemoteBrowserFactory, self).__init__()
         if 'saucelabs' in remote_url:
+            self.remote_client = SauceLabs()
             self.capabilities = SauceLabs.capabilities
             self.remote_url = SauceLabs.URL
             logger.debug('Connecting to SauceLabs instance: {}'.format(self.remote_url))
         elif 'browserstack' in remote_url:
+            self.remote_client = BrowserStack()
             self.capabilities = BrowserStack.capabilities
             self.remote_url = BrowserStack.URL
             logger.debug('Connecting to BrowserStack instance: {}'.format(self.remote_url))

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -23,7 +23,7 @@ import shutil
 import subprocess
 import time
 
-from sst.remote_capabilities import SauceLabs, BrowserStack
+from sst.remote_capabilities import SauceLabs
 
 from selenium import webdriver
 from selenium.common import exceptions as selenium_exceptions
@@ -90,12 +90,7 @@ class RemoteBrowserFactory(BrowserFactory):
                                 'your test directory with your SauceLabs '
                                 'USERNAME, ACCESS_KEY, URL, '
                                 'and CAPABILITIES set.')
-        elif 'browserstack' in remote_url:
-            self.remote_client = BrowserStack()
-            self.capabilities = BrowserStack.capabilities
-            self.remote_url = BrowserStack.URL
-            logger.debug('Connecting to BrowserStack instance: {}'
-                         .format(self.remote_url))
+
         else:
             self.capabilities = capabilities
             self.remote_url = remote_url

--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -200,20 +200,24 @@ class SSTTestCase(testtools.TestCase):
         if self.case_id:
             failed = self.getDetails()
             status_id = testrail_helper.FAILED_TEST_RESULT_STATUS if failed \
-                   else testrail_helper.APITestStatus.PASSED
+                else testrail_helper.APITestStatus.PASSED
             comment = failed['traceback'].as_text() if failed else None
-            return { 'case_id': self.case_id,
-                     'status_id': status_id,
-                     'comment': comment }
+            return {'case_id': self.case_id,
+                    'status_id': status_id,
+                    'comment': comment}
         logger.debug("Could not find case_id for {}".format(self.id()))
         return None
 
     def post_remote_result(self):
         result = False if self.getDetails() else True
         if isinstance(self.remote_client, SauceLabs):
-            self.remote_client.send_result(self.browser.session_id, name=self.id(), result=result)
+            self.remote_client.send_result(session_id=self.browser.session_id,
+                                           name=self.id(),
+                                           result=result)
         elif isinstance(self.remote_client, BrowserStack):
-            self.remote_client.send_result(self.browser.session_id, result=result)
+            self.remote_client.send_result(session_id=self.browser.session_id,
+                                           result=result)
+
 
 class SSTScriptTestCase(SSTTestCase):
     """Test case used internally by sst-run and sst-remote."""
@@ -236,7 +240,7 @@ class SSTScriptTestCase(SSTTestCase):
         # get id from script name for use when posting
         # results to an external test case management tool
         try:
-            self.case_id = int(filter(lambda x:x.isdigit(), self.script_name))
+            self.case_id = int(filter(lambda x: x.isdigit(), self.script_name))
         except ValueError:
             # if script name doesn't contain a number skip it
             pass

--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -41,7 +41,7 @@ from sst import (
     proxy,
     xvfbdisplay
 )
-from sst.remote_capabilities import SauceLabs, BrowserStack
+from sst.remote_capabilities import SauceLabs
 
 logger = logging.getLogger('SST')
 
@@ -214,10 +214,6 @@ class SSTTestCase(testtools.TestCase):
             self.remote_client.send_result(session_id=self.browser.session_id,
                                            name=self.id(),
                                            result=result)
-        elif isinstance(self.remote_client, BrowserStack):
-            self.remote_client.send_result(session_id=self.browser.session_id,
-                                           result=result)
-
 
 class SSTScriptTestCase(SSTTestCase):
     """Test case used internally by sst-run and sst-remote."""

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -109,7 +109,7 @@ def get_common_options():
     parser.add_option('-t', dest='api_test_results', default=None,
                       help=('select when to send API test results '
                       '(per_case, per_suite)'))
-    parser.add_option('-p', dest='use_proxy',
+    parser.add_option('--proxy', dest='use_proxy',
                        action='store_true', default=False,
                        help='enables BrowserMob proxy and stores HTTP archive'
                        ' files for each test. refer src/sst/proxy.py')

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -113,6 +113,9 @@ def get_common_options():
                        action='store_true', default=False,
                        help='enables BrowserMob proxy and stores HTTP archive'
                        ' files for each test. refer src/sst/proxy.py')
+    parser.add_option('-c', '--concurrency', dest='concurrency',
+                      default=1, type='int',
+                      help='concurrency (number of procs)')
     return parser
 
 

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -107,12 +107,12 @@ def get_common_options():
                       default=None,
                       help='directory to output results to')
     parser.add_option('-t', dest='api_test_results', default=None,
-                      help=('select when to send API test results '
-                      '(per_case, per_suite)'))
+                      help='select when to send API test results '
+                           '(per_case, per_suite)')
     parser.add_option('--proxy', dest='use_proxy',
-                       action='store_true', default=False,
-                       help='enables BrowserMob proxy and stores HTTP archive'
-                       ' files for each test. refer src/sst/proxy.py')
+                      action='store_true', default=False,
+                      help='enables BrowserMob proxy and stores HTTP archive'
+                      ' files for each test. refer src/sst/proxy.py')
     parser.add_option('-c', '--concurrency', dest='concurrency',
                       default=1, type='int',
                       help='concurrency (number of procs)')

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -124,9 +124,6 @@ def get_run_options():
     parser.add_option('-x', dest='xserver_headless',
                       default=False, action='store_true',
                       help='run browser in headless xserver (Xvfb)')
-    parser.add_option('-c', '--concurrency', dest='concurrency',
-                      default=1, type='int',
-                      help='concurrency (number of procs)')
     return parser
 
 

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -40,22 +40,3 @@ class SauceLabs(object):
         logger.debug('Sending result to SauceLabs')
         self.client.jobs.update_job(job_id=session_id, name=name,
                                     passed=result)
-
-class BrowserStack(object):
-    USERNAME = ''
-    ACCESS_KEY = ''
-    URL = 'http://{}:{}@hub.browserstack.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
-    results = []
-    capabilities = {'browser': 'Chrome', 'browser_version': '52.0',
-                    'os': 'Windows', 'os_version': '7',
-                    'resolution': '1920x1080',
-                    'browserstack.debug': True,
-                    'chromeOptions': {'args': '--disable-extensions'}}
-
-    def __init__(self):
-        logger.debug('Creating BrowserStack client')
-
-    def send_result(self, session_id, result):
-        logger.debug('Sending result to Browserstack')
-        status = "completed" if result else "error"
-        requests.put('https://username:accesskey@www.browserstack.com/automate/sessions/{}.json'.format(session_id), data={"status": status, "reason": ""})

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -18,10 +18,16 @@
 #
 
 class SauceLabs(object):
+    USERNAME = ''
+    ACCESS_KEY = ''
+    URL = 'http://{}:{}@ondemand.saucelabs.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
     capabilities = {'browserName': 'chrome', 'platform': 'Windows 7',
                     'version': '51.0', 'screenResolution': '1920x1200'}
 
 class BrowserStack(object):
+    USERNAME = ''
+    ACCESS_KEY = ''
+    URL = 'http://{}:{}@hub.browserstack.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
     capabilities = {'browser': 'Chrome', 'browser_version': '52.0',
                     'os': 'Windows', 'os_version': '7',
                     'resolution': '1920x1080',

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -25,8 +25,8 @@ logger = logging.getLogger('SST')
 
 class SauceLabs(object):
     client = None
-    USERNAME = 'rmdaggett'
-    ACCESS_KEY = '5e95db45-67e7-46a6-b95d-79cb68bb2ff0'
+    USERNAME = ''
+    ACCESS_KEY = ''
     URL = 'http://{}:{}@ondemand.saucelabs.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
     results = []
     capabilities = {'browserName': 'chrome', 'platform': 'Windows 7',
@@ -40,8 +40,8 @@ class SauceLabs(object):
         self.client.jobs.update_job(job_id=session_id, name=name, passed=result)
 
 class BrowserStack(object):
-    USERNAME = 'ryandaggett1'
-    ACCESS_KEY = 'jeP4x8qypqsa3PYZabRd'
+    USERNAME = ''
+    ACCESS_KEY = ''
     URL = 'http://{}:{}@hub.browserstack.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
     results = []
     capabilities = {'browser': 'Chrome', 'browser_version': '52.0',
@@ -55,4 +55,4 @@ class BrowserStack(object):
 
     def send_result(self, session_id, result):
         status = "completed" if result else "error"
-        requests.put('https://ryandaggett2:1PJNUhQkZyqfgECzPuPy@www.browserstack.com/automate/sessions/{}.json'.format(session_id), data={"status": status, "reason": ""})
+        requests.put('https://username:accesskey@www.browserstack.com/automate/sessions/{}.json'.format(session_id), data={"status": status, "reason": ""})

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -1,0 +1,29 @@
+#
+#   Copyright (c) 2011-2013 Canonical Ltd.
+#
+#   This file is part of: SST (selenium-simple-test)
+#   https://launchpad.net/selenium-simple-test
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+class SauceLabs(object):
+    capabilities = {'browserName': 'chrome', 'platform': 'Windows 7',
+                    'version': '51.0', 'screenResolution': '1920x1200'}
+
+class BrowserStack(object):
+    capabilities = {'browser': 'Chrome', 'browser_version': '52.0',
+                    'os': 'Windows', 'os_version': '7',
+                    'resolution': '1920x1080',
+                    'browserstack.debug': True,
+                    'chromeOptions': {'args': '--disable-extensions'}}

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -17,19 +17,42 @@
 #   limitations under the License.
 #
 
+import logging
+import requests
+import sauceclient
+
+logger = logging.getLogger('SST')
+
 class SauceLabs(object):
-    USERNAME = ''
-    ACCESS_KEY = ''
+    client = None
+    USERNAME = 'rmdaggett'
+    ACCESS_KEY = '5e95db45-67e7-46a6-b95d-79cb68bb2ff0'
     URL = 'http://{}:{}@ondemand.saucelabs.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
+    results = []
     capabilities = {'browserName': 'chrome', 'platform': 'Windows 7',
-                    'version': '51.0', 'screenResolution': '1920x1200'}
+                    'version': '52.0', 'screenResolution': '1920x1200'}
+
+    def __init__(self):
+        logger.debug('Creating sauceclient')
+        self.client = sauceclient.SauceClient(self.USERNAME, self.ACCESS_KEY,)
+
+    def send_result(self, session_id, name, result):
+        self.client.jobs.update_job(job_id=session_id, name=name, passed=result)
 
 class BrowserStack(object):
-    USERNAME = ''
-    ACCESS_KEY = ''
+    USERNAME = 'ryandaggett1'
+    ACCESS_KEY = 'jeP4x8qypqsa3PYZabRd'
     URL = 'http://{}:{}@hub.browserstack.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
+    results = []
     capabilities = {'browser': 'Chrome', 'browser_version': '52.0',
                     'os': 'Windows', 'os_version': '7',
                     'resolution': '1920x1080',
                     'browserstack.debug': True,
                     'chromeOptions': {'args': '--disable-extensions'}}
+
+    def __init__(self):
+        logger.debug('Creating BrowserStack client')
+
+    def send_result(self, session_id, result):
+        status = "completed" if result else "error"
+        requests.put('https://ryandaggett2:1PJNUhQkZyqfgECzPuPy@www.browserstack.com/automate/sessions/{}.json'.format(session_id), data={"status": status, "reason": ""})

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -24,21 +24,22 @@ import sauceclient
 logger = logging.getLogger('SST')
 
 class SauceLabs(object):
-    client = None
-    USERNAME = ''
-    ACCESS_KEY = ''
-    URL = 'http://{}:{}@ondemand.saucelabs.com:80/wd/hub'.format(USERNAME, ACCESS_KEY)
-    results = []
-    capabilities = {'browserName': 'chrome', 'platform': 'Windows 7',
-                    'version': '52.0', 'screenResolution': '1920x1200'}
+    """Helper class for creating an instance of sauceclient and posting results.
+    Credentials should be defined in the directory where your tests
+    are stored in a sauce_config.py module."""
 
-    def __init__(self):
+    client = None
+    URL = None
+
+    def __init__(self, username, access_key, url):
         logger.debug('Creating SauceLabs client')
-        self.client = sauceclient.SauceClient(self.USERNAME, self.ACCESS_KEY,)
+        self.URL = url
+        self.client = sauceclient.SauceClient(username, access_key,)
 
     def send_result(self, session_id, name, result):
         logger.debug('Sending result to SauceLabs')
-        self.client.jobs.update_job(job_id=session_id, name=name, passed=result)
+        self.client.jobs.update_job(job_id=session_id, name=name,
+                                    passed=result)
 
 class BrowserStack(object):
     USERNAME = ''

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -33,10 +33,11 @@ class SauceLabs(object):
                     'version': '52.0', 'screenResolution': '1920x1200'}
 
     def __init__(self):
-        logger.debug('Creating sauceclient')
+        logger.debug('Creating SauceLabs client')
         self.client = sauceclient.SauceClient(self.USERNAME, self.ACCESS_KEY,)
 
     def send_result(self, session_id, name, result):
+        logger.debug('Sending result to SauceLabs')
         self.client.jobs.update_job(job_id=session_id, name=name, passed=result)
 
 class BrowserStack(object):
@@ -54,5 +55,6 @@ class BrowserStack(object):
         logger.debug('Creating BrowserStack client')
 
     def send_result(self, session_id, result):
+        logger.debug('Sending result to Browserstack')
         status = "completed" if result else "error"
         requests.put('https://username:accesskey@www.browserstack.com/automate/sessions/{}.json'.format(session_id), data={"status": status, "reason": ""})

--- a/src/sst/scripts/remote.py
+++ b/src/sst/scripts/remote.py
@@ -28,6 +28,7 @@ testtools.try_import('selenium')
 from sst import (
     browsers,
     command,
+    config,
     runtests,
 )
 
@@ -37,6 +38,9 @@ def main():
 
     results_directory = os.path.abspath('results')
     command.reset_directory(results_directory)
+
+    if cmd_opts.api_test_results:
+        config.api_test_results = cmd_opts.api_test_results
 
     browser_factory = browsers.RemoteBrowserFactory(
         {
@@ -58,7 +62,8 @@ def main():
         extended=cmd_opts.extended_tracebacks,
         concurrency_num=cmd_opts.concurrency,
         # FIXME: not tested -- vila 2013-05-23
-        excludes=cmd_opts.excludes
+        excludes=cmd_opts.excludes,
+        api_test_results=cmd_opts.api_test_results
     )
 
 

--- a/src/sst/scripts/remote.py
+++ b/src/sst/scripts/remote.py
@@ -48,7 +48,7 @@ def main():
     runtests.runtests(
         args, results_directory, sys.stdout,
         test_dir=cmd_opts.dir_name,
-        count_only=cmd_opts.count_only,
+        collect_only=cmd_opts.collect_only,
         report_format=cmd_opts.report_format,
         browser_factory=browser_factory,
         shared_directory=cmd_opts.shared_directory,

--- a/src/sst/scripts/remote.py
+++ b/src/sst/scripts/remote.py
@@ -56,6 +56,7 @@ def main():
         failfast=cmd_opts.failfast,
         debug=cmd_opts.debug,
         extended=cmd_opts.extended_tracebacks,
+        concurrency_num=cmd_opts.concurrency,
         # FIXME: not tested -- vila 2013-05-23
         excludes=cmd_opts.excludes
     )


### PR DESCRIPTION
this is a very hacky/WIP/proof-of-concept PR showing off connecting the sst framework to cloud-based cross-browser testing tools like [SauceLabs](https://saucelabs.com/beta/dashboard/tests) or [BrowserStack](https://www.browserstack.com/automate). still have a lot to work through here but I wanted to push this up for folks to to have a look and start collecting feedback.

to run a test on browserstack:

```
sst-remote home_page_ads_278.py -u http://<browserstack user>:<browserstack key>@hub.browserstack.com:80/wd/hub
```

to run a test on saucelabs:

```
sst-remote home_page_ads_278.py -u http://<saucelabs user>:<saucelabs key>@ondemand.saucelabs.com:80/wd/hub
```

@DramaFever/qa 
