### PR TITLE
add testrail_api module to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from sst import __version__
 
 
 NAME = 'sst'
-PACKAGES = ['sst', 'sst.scripts', 'sst.tests']
+PACKAGES = ['sst', 'sst.scripts', 'sst.tests', 'sst.testrail_api']
 DESCRIPTION = 'SST - Web Test Framework'
 URL = 'http://testutils.org/sst'
 LICENSE = 'Apache'


### PR DESCRIPTION
fixes:
```
Traceback (most recent call last):
  File "/usr/local/bin/sst-run", line 9, in <module>
    load_entry_point('sst==0.2.5.dev0', 'console_scripts', 'sst-run')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 521, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2632, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2312, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2318, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/dist-packages/sst-0.2.5.dev0-py2.7.egg/sst/scripts/run.py", line 31, in <module>
    from sst import (
  File "/usr/local/lib/python2.7/dist-packages/sst-0.2.5.dev0-py2.7.egg/sst/runtests.py", line 27, in <module>
    from testrail_api.testrail import APIError
ImportError: No module named testrail_api.testrail
```

@DramaFever/qa 