### PR TITLE
Pull credentials for test case manager from the test project

### DIFF
--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -180,15 +180,15 @@ class SSTTestCase(testtools.TestCase):
         try:
             result = self._get_case_result()
             if result:
-                testrail_helper.send_result(result['case_id'],
-                                            result['status_id'],
-                                            result['comment'])
+                config.api_client.send_result(result['case_id'],
+                                              result['status_id'],
+                                              result['comment'])
         except APIError, e:
             logger.debug("Could not send test case result \n" + str(e))
 
     def _store_case_result(self):
         if self._get_case_result():
-            testrail_helper.run_results.append(self._get_case_result())
+            config.api_client.run_results.append(self._get_case_result())
 
     def _get_case_result(self):
         if self.case_id:

--- a/src/sst/config.py
+++ b/src/sst/config.py
@@ -53,6 +53,7 @@ _current_context = None
 shared_directory = None
 results_directory = None
 api_test_results = None
+api_client = None
 flags = []
 __args__ = {}
 cache = {}

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -17,6 +17,7 @@
 #   limitations under the License.
 #
 
+import imp
 import junitxml
 import logging
 import os
@@ -139,6 +140,13 @@ def post_api_test_results():
         testrail_helper.send_results()
     except APIError, e:
         logger.debug("Could not send test results \n" + str(e))
+
+def find_api_creds_module():
+    cwd = os.getcwd()
+    mod_path = os.path.join(cwd, 'testrail_config.py')
+    if not os.path.isfile(mod_path):
+        mod_path = os.path.join(os.path.dirname(cwd), 'testrail_config.py')
+    return imp.load_source('testrail_config', os.path.abspath(mod_path))
 
 def find_shared_directory(test_dir, shared_directory):
     """This function is responsible for finding the shared directory.

--- a/src/sst/testrail_helper.py
+++ b/src/sst/testrail_helper.py
@@ -6,56 +6,58 @@ from testrail_api.testrail import *
 
 logger = logging.getLogger('SST')
 
-client = APIClient('https://dramafever.testrail.net/')
+class TestRailHelper(object):
 
-client.user = ''
-client.password = ''
+    def __init__(self, url, user, password, project_id):
+        self.client = APIClient(url)
+        self.client.user = user
+        self.client.password = password
+        self.project_id = project_id
+        self.run_results = []
+        self.run_id = None
 
-run_results = []
-project_id = 3
-run_id = None
+    def create_test_run(self, case_ids):
+        time = datetime.now().time().strftime("%I:%M %p")
+        try:
+            run = self.client.send_post('add_run/{}'.format(self.project_id),
+                  {
+                      "name": "Automation Test Run {}".format(time),
+                      "include_all": False,
+                      "case_ids": case_ids
+                  }
+            )
+            return run['id']
+        except Exception as e:
+            logger.debug("Could not create TestRail test run \n" + str(e))
 
-def create_test_run(case_ids):
-    time = datetime.now().time().strftime("%I:%M %p")
-    try:
-        run = client.send_post('add_run/{}'.format(project_id),
-            {
-                "name": "Automation Test Run {}".format(time),
-                "include_all": False,
-                "case_ids": case_ids
-            }
-        )
-        return run['id']
-    except Exception as e:
-        logger.debug("Could not create TestRail test run \n" + str(e))
+    # add test case results to test run
+    def send_results(self):
+        self.store_json_results(self.run_results)
+        try:
+            run = self.client.send_post('add_results_for_cases/{}'
+                      .format(self.run_id),
+                      { "results": self.run_results }
+            )
+        except Exception as e:
+            logger.debug("Could not send TestRail results \n" + str(e))
 
-# add test case results to test run
-def send_results():
-    store_json_results(run_results)
-    try:
-        run = client.send_post('add_results_for_cases/{}'.format(run_id),
-    		{ "results": run_results }
-        )
-    except Exception as e:
-        logger.debug("Could not send TestRail results \n" + str(e))
+    # add individual test case result to test run
+    def send_result(self, case_id, status_id, comment=None):
+        result = {
+            "status_id": status_id,
+            "comment": comment
+        }
+        self.store_json_results(result, case_id)
+        try:
+            run = self.client.send_post('add_result_for_case/{}/{}'
+                                        .format(self.run_id, case_id), result)
+        except Exception as e:
+            logger.debug("Could not send TestRail results \n" + str(e))
 
-# add individual test case result to test run
-def send_result(case_id, status_id, comment=None):
-    result = {
-        "status_id": status_id,
-        "comment": comment
-    }
-    store_json_results(result, case_id)
-    try:
-        run = client.send_post('add_result_for_case/{}/{}'
-                               .format(run_id, case_id), result)
-    except Exception as e:
-        logger.debug("Could not send TestRail results \n" + str(e))
-
-def store_json_results(result, case_id=''):
-    filename = '{}/{}results.json'.format(config.results_directory, case_id)
-    with open(filename, 'w') as outfile:
-        json.dump(result, outfile)
+    def store_json_results(self, result, case_id=''):
+        filename = '{}/{}results.json'.format(config.results_directory, case_id)
+        with open(filename, 'w') as outfile:
+            json.dump(result, outfile)
 
 
 class APITestStatus(object):


### PR DESCRIPTION
Instead of storing our TestRail credentials in sst `testrail_helper.py`, we can store them in our test project. That way we can use different TestRail project_ids for our multiple properties without having to hardcode them into sst.

For this to work, you'll need this partner PR with the TestRail credentials: https://github.com/DramaFever/testing/pull/464

Test this by running:
```
sst-run -d . -b Chrome -t per_case
```
from the `testing` dir or any testing subfolder (e.g. `browse_page_tests`).

@DramaFever/qa 
