### PR TITLE
Set timezone to US/Eastern for test run timestamp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-subunit
 selenium==2.53.0
 testtools==1.8.0
 browsermob-proxy==0.7.1
+pytz==2013.7

--- a/src/sst/testrail_helper.py
+++ b/src/sst/testrail_helper.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import datetime
+from pytz import timezone
 from sst import config
 from testrail_api.testrail import *
 
@@ -17,7 +18,8 @@ class TestRailHelper(object):
         self.run_id = None
 
     def create_test_run(self, case_ids):
-        time = datetime.now().time().strftime("%I:%M %p")
+        tz = timezone('US/Eastern')
+        time = datetime.now(tz).time().strftime("%I:%M %p")
         try:
             run = self.client.send_post('add_run/{}'.format(self.project_id),
                   {


### PR DESCRIPTION
Test runs in TestRail will now have a timestamp in our time zone so it's easier for us to know when the tests ran. `pytz` will handle the transition between daylight savings.

@DramaFever/qa 