### PR TITLE
Add support for Appium

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 junitxml
 python-subunit
 selenium==3.4.3
+Appium-Python-Client==0.24
 testtools==1.8.0
 browsermob-proxy==0.7.1
 sauceclient==0.2.1

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -22,6 +22,7 @@ import platform
 import shutil
 import subprocess
 import time
+import appium
 
 from sst.remote_capabilities import SauceLabs
 
@@ -114,6 +115,21 @@ class ChromeFactory(BrowserFactory):
 
     def browser(self):
         return self.webdriver_class(desired_capabilities=self.capabilities)
+
+
+class AppiumFactory(BrowserFactory):
+
+    webdriver_class = appium.webdriver.Remote
+
+    def setup_for_test(self, test):
+        from sst import runtests
+        creds = runtests.set_client_credentials('appium')
+        self.server, self.caps = creds.SERVER, creds.CAPABILITIES
+        logger.debug("Appium capabilities: {}".format(self.caps))
+
+    def browser(self):
+        return self.webdriver_class(self.server, self.caps)
+
 
 # MISSINGTEST: Exercise this class (requires windows) -- vila 2013-04-11
 class IeFactory(BrowserFactory):
@@ -253,4 +269,5 @@ browser_factories = {
     'Ie': IeFactory,
     'Opera': OperaFactory,
     'PhantomJS': PhantomJSFactory,
+    'Appium': AppiumFactory
 }

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -120,7 +120,6 @@ class RemoteBrowserFactory(BrowserFactory):
                         'deviceName': test.context['deviceName'],
                         'platformVersion': test.context['platformVersion'],
                         'platformName': test.context['platformName'],
-                        'browserName': test.context['browserName'],
                         'newCommandTimeout': test.context['newCommandTimeout']}
             if self.capabilities['platformName'] is 'Android':
                 self.capabilities.update({

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -102,7 +102,7 @@ class RemoteBrowserFactory(BrowserFactory):
             self.remote_url = remote_url
 
     def setup_for_test(self, test):
-        if self.webdriver_class is webdriver.Remote:
+        if self.webdriver_class == webdriver.Remote:
             self.capabilities = {
                         'platform': test.context['platform'],
                         'browserName': test.context['browserName'],
@@ -113,7 +113,7 @@ class RemoteBrowserFactory(BrowserFactory):
                 self.capabilities.update({
                         'chromeOptions': test.context['chromeOptions']})
 
-        elif self.webdriver_class is appium.webdriver.Remote:
+        elif self.webdriver_class == appium.webdriver.Remote:
             self.capabilities = {
                         'app': test.context['app'],
                         'appiumVersion': test.context['appiumVersion'],
@@ -121,7 +121,7 @@ class RemoteBrowserFactory(BrowserFactory):
                         'platformVersion': test.context['platformVersion'],
                         'platformName': test.context['platformName'],
                         'newCommandTimeout': test.context['newCommandTimeout']}
-            if self.capabilities['platformName'] is 'Android':
+            if self.capabilities['platformName'] == 'Android':
                 self.capabilities.update({
                         'appPackage': test.context['appPackage'],
                         'appActivity': test.context['appActivity']})

--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -134,7 +134,6 @@ class SSTTestCase(testtools.TestCase):
             except exceptions.WebDriverException:
                 if nb_attempts >= max_attempts:
                     raise
-        import pdb; pdb.set_trace()
         try:
             logger.debug('Browser started: %s' % self.browser.name)
         except KeyError:

--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -134,7 +134,12 @@ class SSTTestCase(testtools.TestCase):
             except exceptions.WebDriverException:
                 if nb_attempts >= max_attempts:
                     raise
-        logger.debug('Browser started: %s' % self.browser.name)
+        import pdb; pdb.set_trace()
+        try:
+            logger.debug('Browser started: %s' % self.browser.name)
+        except KeyError:
+            (logger.debug('Device started: %s' %
+                           self.browser.capabilities['desired']['deviceName']))
 
     def stop_browser(self):
         logger.debug('Stopping browser')
@@ -259,8 +264,13 @@ class SSTScriptTestCase(SSTTestCase):
         # Possibly inject parametrization from associated .csv file
         previous_context = context.store_context()
         self.addCleanup(context.restore_context, previous_context)
-        context.populate_context(self.context, self.script_path,
-                                 self.browser.name)
+        try:
+            context.populate_context(self.context, self.script_path,
+                                     self.browser.name)
+        except KeyError:
+            (context.populate_context(self.context, self.script_path,
+                                      self.browser
+                                      .capabilities['desired']['deviceName']))
 
     def _compile_script(self):
         self.script_path = os.path.join(self.script_dir, self.script_name)

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -99,23 +99,24 @@ def runtests(test_regexps, results_directory, out,
                 tests = [t.case_id for t in alltests._tests if t.case_id]
                 ids = list(OrderedDict.fromkeys(tests))
                 try:
-                    browser_name = browser['browserName']
+                    browser_name = 'browserName'
                     platform_string = '{} - {} - {}'.format(
                                        browser['platform'],
-                                       browser_name,
+                                       browser[browser_name],
                                        browser['version'])
                 except KeyError:
-                    browser_name = browser['deviceName']
+                    browser_name = 'deviceName'
                     platform_string = '{} - {}'.format(
-                                       browser_name,
+                                       browser[browser_name],
                                        browser['platformVersion'])
                 test_run = client.create_test_run(ids, platform_string)
                 logger.debug('Cases in current run ({}:{}): {}'.format(
-                              browser_name,
+                              browser[browser_name],
                               test_run['run_id'],
                               ids))
                 for test in alltests._tests:
-                    test.run_id = test_run['run_id']
+                    if browser[browser_name] in test.context[browser_name]:
+                        test.run_id = test_run['run_id']
             logger.debug('Created test runs {} using the above cases'
                          .format(client.runs))
         else:

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -159,6 +159,9 @@ def set_client_credentials(client):
     elif client == 'saucelabs':
         return find_client_credentials('sauce_config')
 
+    elif client == 'appium':
+        return find_client_credentials('appium_config')
+
 def find_shared_directory(test_dir, shared_directory):
     """This function is responsible for finding the shared directory.
     It implements the following rule:

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -98,18 +98,24 @@ def runtests(test_regexps, results_directory, out,
             for browser in browser_factory.browsers:
                 tests = [t.case_id for t in alltests._tests if t.case_id]
                 ids = list(OrderedDict.fromkeys(tests))
-
-                platform_string = '{} - {} - {}'.format(browser['platform'],
-                                                        browser['browserName'],
-                                                        browser['version'])
+                try:
+                    browser_name = browser['browserName']
+                    platform_string = '{} - {} - {}'.format(
+                                       browser['platform'],
+                                       browser_name,
+                                       browser['version'])
+                except KeyError:
+                    browser_name = browser['deviceName']
+                    platform_string = '{} - {}'.format(
+                                       browser_name,
+                                       browser['platformVersion'])
                 test_run = client.create_test_run(ids, platform_string)
                 logger.debug('Cases in current run ({}:{}): {}'.format(
-                              browser['browserName'],
+                              browser_name,
                               test_run['run_id'],
                               ids))
                 for test in alltests._tests:
-                    if browser['browserName'] in test.context['browserName']:
-                        test.run_id = test_run['run_id']
+                    test.run_id = test_run['run_id']
             logger.debug('Created test runs {} using the above cases'
                          .format(client.runs))
         else:


### PR DESCRIPTION
I created an `AppiumFactory` class so we can run our mobile Appium tests with SST. The credentials are pulled in from a config file stored by the client project. When running mobile tests we just need to set the browser flag, i.e. `-b Appium`.

This can be tested with the partner PR in our android project: https://github.com/DramaFever/testing-android/pull/13

@DramaFever/qa 