### PR TITLE
try poll_for_element to alleviate cannot determine loading status bugs

### DIFF
--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -52,6 +52,7 @@ from pdb import set_trace as debug
 from urlparse import urljoin, urlparse
 
 from selenium.webdriver.common import action_chains, keys
+from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -67,7 +68,7 @@ from selenium.common.exceptions import (
 
 from sst import config
 
-__all__ = [
+__all__ = (
     'accept_alert', 'add_cleanup', 'assert_attribute', 'assert_button',
     'assert_checkbox', 'assert_checkbox_value', 'assert_css_property',
     'assert_displayed', 'assert_dropdown', 'assert_dropdown_value',
@@ -94,7 +95,7 @@ __all__ = [
     'switch_to_active_window', 'switch_to_frame', 'switch_to_window',
     'take_screenshot', 'toggle_checkbox', 'wait_for', 'wait_for_and_refresh',
     'write_textfield'
-]
+)
 
 
 _check_flags = True
@@ -1373,8 +1374,7 @@ def get_element_by_xpath(selector):
 
 
 def _waitforbody():
-    wait_for(get_element, tag='body')
-
+    poll_for_element((By.TAG_NAME, 'body'))
 
 def get_page_source():
     """Gets the source of the current page."""
@@ -1881,6 +1881,7 @@ def poll_for_element(locator, wait=10, frequency=1):
 
     """
     try:
+        logger.debug("Waiting for element: {}".format(locator))
         return (WebDriverWait(_test.browser, wait, poll_frequency=frequency)
                .until(EC.visibility_of_element_located(locator)))
     except TimeoutException:


### PR DESCRIPTION
use `poll_for_element` in `_waitforbody` instead of `wait_for` which heavily uses timeouts.

https://sqa.stackexchange.com/questions/9007/how-to-handle-time-out-receiving-message-from-the-renderer-in-chrome-driver

http://stackoverflow.com/questions/40273832/selenium-chromedriver-2-25-timeoutexception-cannot-determine-loading-status

the aim is to address and alleviate these types of issues, which are unclear where they are originating from. the post above suggests removing timeouts may help. it looks like `_waitforbody` was calling `wait_for` which in turn calls `_wait_for`. this function uses timeouts, sleeps, and retries heavily and may be causing some of our frustration. Local testing shows this works.

```
File "/usr/local/lib/python2.7/dist-packages/sst-0.2.5.dev0-py2.7.egg/sst/actions.py", line 368, in go_to
    _test.browser.get(url)
  File "/usr/local/lib/python2.7/dist-packages/selenium-2.53.0-py2.7.egg/selenium/webdriver/remote/webdriver.py", line 245, in get
    self.execute(Command.GET, {'url': url})
  File "/usr/local/lib/python2.7/dist-packages/selenium-2.53.0-py2.7.egg/selenium/webdriver/remote/webdriver.py", line 233, in execute
    self.error_handler.check_response(response)
  File "/usr/local/lib/python2.7/dist-packages/selenium-2.53.0-py2.7.egg/selenium/webdriver/remote/errorhandler.py", line 194, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.TimeoutException: Message: timeout: cannot determine loading status
from timeout: Timed out receiving message from renderer: -0.003
  (Session info: chrome=53.0.2785.143)
  (Driver info: chromedriver=2.23.409687 (c46e862757edc04c06b1bd88724d15a5807b84d1),platform=Linux 3.13.0-100-generic x86_64)
```

@DramaFever/qa 

