### PR TITLE
if chromeOptions key is present, set capabilities

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -102,6 +102,9 @@ class RemoteBrowserFactory(BrowserFactory):
                              'version': test.context['version'],
                              'screenResolution': test.context['screenResolution'],
                              'idleTimeout': 300}
+        if 'chromeOptions' in test.context:
+            self.capabilities['chromeOptions'] = test.context['chromeOptions']
+
         logger.debug('Remote capabilities set: {}'.format(self.capabilities))
 
     def browser(self):


### PR DESCRIPTION
if `chromeOptions` key is present in the capabilities dict from sauce config, send it along

@DramaFever/qa 