### PR TITLE
retry go_to on TimeoutException

### DIFF
--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -351,7 +351,7 @@ def run_test(name, **kwargs):
     logger.debug('Executing test: %s' % name)
     return context.run_test(name, kwargs)
 
-
+@retry_on_exception(TimeoutException, retries=1)
 def go_to(url='', wait=True):
     """Go to a URL.
 


### PR DESCRIPTION
occasionally tests will fail because of third party dependencies like ad pixels. we have added a proxy in front of our tests which allows us to catch and blacklist offenders, but we can also catch page timeouts as a result of navigating and retry them once before failing.

to test this you can setup a breakpoint in charles or your favorite proxy tool on some outbound traffic in your application (e.g. `pubmatic.com` for one of the offending dramafever.com ad networks) and run a test. when the test starts and navigates to the homepage via `go_to` the breakpoint should fire and you can just let it sit for the page timeout duration (30 seconds) and see the retry get triggered.

@DramaFever/qa 