### PR TITLE
Add the enum34 package to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ testtools==1.8.0
 browsermob-proxy==0.7.1
 sauceclient==0.2.1
 pytz==2013.7
+enum34==1.1.6


### PR DESCRIPTION
We use this package in our client test projects so it makes sense to pin this in requirements

https://pypi.python.org/pypi/enum34