### PR TITLE
fix logging

### DIFF
--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -1846,10 +1846,9 @@ def poll_for_staleness(id_or_elem, wait=10, frequency=1):
 
     """
     elem = _get_elem(id_or_elem)
-    elem_string = _element_to_string(elem)
     try:
         logger.debug('Waiting for element to be removed from DOM: {}'
-                     .format(elem_string))
+                     .format(elem))
         return (WebDriverWait(_test.browser, wait, poll_frequency=frequency)
                .until(EC.staleness_of(elem)))
     except TimeoutException:


### PR DESCRIPTION
dont call _element_to_string which will in some cases attempt to get attributes or text of an attempt after it has been removed from the DOM, causing a StaleElementReferenceException

@DramaFever/qa 