### PR TITLE
enable network and js logs for saucelabs runs

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -108,6 +108,7 @@ class RemoteBrowserFactory(BrowserFactory):
                         'browserName': test.context['browserName'],
                         'version': test.context['version'],
                         'screenResolution': test.context['screenResolution'],
+                        'extendedDebugging': True,
                         'idleTimeout': 300}
             if 'chromeOptions' in test.context:
                 self.capabilities.update({


### PR DESCRIPTION
this will enable generation of HAR files and js logs for runs on saucelabs

https://saucelabs.com/beta/tests/b1e0da76314e46008d6ac563db687b37/network#115

@DramaFever/qa 