### PR TITLE
Appium Real Device automation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 junitxml
 python-subunit
 selenium==3.4.3
-Appium-Python-Client==0.24
+Appium-Python-Client==0.44
 testtools==1.8.0
 browsermob-proxy==0.7.1
 sauceclient==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ selenium==3.141.0
 Appium-Python-Client==0.44
 testtools==1.8.0
 browsermob-proxy==0.7.1
-sauceclient==0.2.1
+git+git://github.com/cgoldberg/sauceclient.git@aa27b7d
 pytz==2013.7
 enum34==1.1.6
 urllib3==1.24.3
+python-dateutil

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -81,16 +81,20 @@ class RemoteBrowserFactory(BrowserFactory):
             from sst import runtests
             self.creds = runtests.set_client_credentials('saucelabs')
             try:
-                self.remote_client = SauceLabs(self.creds.USERNAME,
-                                               self.creds.ACCESS_KEY,
-                                               self.creds.URL)
                 self.browsers = self.creds.CAPABILITIES
-                
+                apibase = None
+
                 if 'APPIUM_URL' in dir(self.creds):
                     self.remote_url = self.creds.APPIUM_URL
                     self.webdriver_class = appium.webdriver.Remote
+                    apibase = self.creds.API_BASE
                 else:
-                    self.remote_url = self.remote_client.URL
+                    self.remote_url = self.creds.URL
+
+                self.remote_client = SauceLabs(self.creds.USERNAME,
+                                               self.creds.ACCESS_KEY,
+                                               self.creds.URL,
+                                               apibase)
 
                 logger.debug('Connecting to SauceLabs instance: {}'
                              .format(self.remote_url))

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -84,13 +84,13 @@ class RemoteBrowserFactory(BrowserFactory):
                 self.remote_client = SauceLabs(self.creds.USERNAME,
                                                self.creds.ACCESS_KEY,
                                                self.creds.URL)
-                try:
-                    self.browsers = self.creds.CAPABILITIES
-                    self.remote_url = self.remote_client.URL
-                except AttributeError:
+                if 'APPIUM_URL' in dir(self.creds):
                     self.browsers = self.creds.CAPABILITIES
                     self.remote_url = self.creds.APPIUM_URL
                     self.webdriver_class = appium.webdriver.Remote
+                else:
+                    self.browsers = self.creds.CAPABILITIES
+                    self.remote_url = self.remote_client.URL
 
                 logger.debug('Connecting to SauceLabs instance: {}'
                              .format(self.remote_url))

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -84,12 +84,12 @@ class RemoteBrowserFactory(BrowserFactory):
                 self.remote_client = SauceLabs(self.creds.USERNAME,
                                                self.creds.ACCESS_KEY,
                                                self.creds.URL)
+                self.browsers = self.creds.CAPABILITIES
+                
                 if 'APPIUM_URL' in dir(self.creds):
-                    self.browsers = self.creds.CAPABILITIES
                     self.remote_url = self.creds.APPIUM_URL
                     self.webdriver_class = appium.webdriver.Remote
                 else:
-                    self.browsers = self.creds.CAPABILITIES
                     self.remote_url = self.remote_client.URL
 
                 logger.debug('Connecting to SauceLabs instance: {}'

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -114,7 +114,7 @@ class RemoteBrowserFactory(BrowserFactory):
                                                       self.capabilities))
 
     def browser(self):
-        return self.webdriver_class(self.remote_url, self.capabilities)
+        return self.webdriver_class(self.remote_url, self.capabilities[0])
 
 
 # MISSINGTEST: Exercise this class -- vila 2013-04-11

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -85,10 +85,12 @@ class RemoteBrowserFactory(BrowserFactory):
                                                creds.URL)
                 try:
                     self.browsers = creds.BROWSERS
+                    self.remote_url = self.remote_client.URL
                 except AttributeError:
-                    self.browsers = creds.CAPABILITIES
+                    self.browsers = creds.DEVICES
+                    self.remote_url = creds.APPIUM_URL
                     self.webdriver_class = appium.webdriver.Remote
-                self.remote_url = self.remote_client.URL
+
                 logger.debug('Connecting to SauceLabs instance: {}'
                              .format(self.remote_url))
             except:
@@ -102,32 +104,36 @@ class RemoteBrowserFactory(BrowserFactory):
             self.remote_url = remote_url
 
     def setup_for_test(self, test):
+        self.capabilities = {}
         if self.webdriver_class == webdriver.Remote:
             self.capabilities = {
-                        'platform': test.context['platform'],
-                        'browserName': test.context['browserName'],
-                        'version': test.context['version'],
-                        'screenResolution': test.context['screenResolution'],
-                        'extendedDebugging': True,
-                        'idleTimeout': 300}
+                'platform': test.context['platform'],
+                'browserName': test.context['browserName'],
+                'version': test.context['version'],
+                'screenResolution': test.context['screenResolution'],
+                'extendedDebugging': True,
+                'idleTimeout': 300}
             if 'chromeOptions' in test.context:
                 self.capabilities.update({
                         'chromeOptions': test.context['chromeOptions']})
 
         elif self.webdriver_class == appium.webdriver.Remote:
-            self.capabilities = {
-                        'app': test.context['app'],
-                        'appiumVersion': test.context['appiumVersion'],
-                        'deviceName': test.context['deviceName'],
-                        'platformVersion': test.context['platformVersion'],
-                        'platformName': test.context['platformName'],
-                        'newCommandTimeout': test.context['newCommandTimeout']}
-            if self.capabilities['platformName'] == 'Android':
-                self.capabilities.update({
-                        'appPackage': test.context['appPackage'],
-                        'appActivity': test.context['appActivity']})
+            self.capabilities.update({
+                'testobject_api_key': test.context['testobject_api_key'],
+                'testobject_app_id': test.context['testobject_app_id'],
+                'platformName': test.context['platformName'],
+                'appiumVersion': test.context['appiumVersion'],
+                'deviceName': test.context['deviceName'],
+                'deviceOrientation': test.context['deviceOrientation'],
+                'automationName': test.context['automationName'],
+                'platformVersion': test.context['platformVersion'],
+                'app': test.context['app'],
+                'appPackage': test.context['appPackage'],
+                'appActivity': test.context['appActivity']
+            })
 
-        logger.debug('Remote capabilities set: {}'.format(self.capabilities))
+        logger.debug('{} capabilities set: {}'.format(self.webdriver_class,
+                                                      self.capabilities))
 
     def browser(self):
         return self.webdriver_class(self.remote_url, self.capabilities)

--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -212,10 +212,9 @@ class SSTTestCase(testtools.TestCase):
     def post_remote_result(self):
         result = False if self.getDetails() else True
         if isinstance(self.remote_client, SauceLabs):
-            pass
-            #self.remote_client.send_result(session_id=self.browser.session_id,
-            #                               name=self.id(),
-            #                               result=result)
+            self.remote_client.send_result(session_id=self.browser.session_id,
+                                           name=self.id(),
+                                           result=result)
 
 class SSTScriptTestCase(SSTTestCase):
     """Test case used internally by sst-run and sst-remote."""

--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -212,9 +212,10 @@ class SSTTestCase(testtools.TestCase):
     def post_remote_result(self):
         result = False if self.getDetails() else True
         if isinstance(self.remote_client, SauceLabs):
-            self.remote_client.send_result(session_id=self.browser.session_id,
-                                           name=self.id(),
-                                           result=result)
+            pass
+            #self.remote_client.send_result(session_id=self.browser.session_id,
+            #                               name=self.id(),
+            #                               result=result)
 
 class SSTScriptTestCase(SSTTestCase):
     """Test case used internally by sst-run and sst-remote."""

--- a/src/sst/loaders.py
+++ b/src/sst/loaders.py
@@ -217,8 +217,7 @@ class SSTestLoader(TestLoader):
             if self.browser_factory.remote_client:
                 for browser in self.browser_factory.browsers:
                     test = self.loadTestFromScript(dir_name,
-                                                   script_name,
-                                                   browser)
+                                                   script_name)
                     suite.addTest(test)
             else:
                 test = self.loadTestFromScript(dir_name, script_name)

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -17,6 +17,7 @@
 #   limitations under the License.
 #
 
+import json
 import logging
 import requests
 import sauceclient
@@ -31,16 +32,29 @@ class SauceLabs(object):
 
     client = None
     URL = None
+    api_base = None
 
-    def __init__(self, username, access_key, url):
+    def __init__(self, username, access_key, url, apibase=None):
         logger.debug('Creating SauceLabs client')
         self.URL = url
-        self.client = sauceclient.SauceClient(username, access_key,)
+        if apibase:
+            self.api_base = apibase
+        self.client = sauceclient.SauceClient(username, access_key, apibase)
 
     def send_result(self, session_id, name, result):
-        import pdb;pdb.set_trace()
         logger.debug('Sending result to SauceLabs')
         logger.debug('SauceOnDemandSessionID={} job-name={}'.format(session_id,
                                                                     name))
-        self.client.jobs.update_job(job_id=session_id, name=name,
-                                    passed=result)
+        if 'testobject' in self.api_base:
+            self.send_result_testobject(session_id, result)
+        else:
+            self.client.jobs.update_job(job_id=session_id, name=name,
+                                        passed=result)
+
+    def send_result_testobject(self, session_id, result):
+        url = self.api_base + 'v2/appium/session/{}/test'.format(session_id)
+        headers = {"Content-Type": "application/json"}
+        result_dict = {"passed": result}
+        r = requests.put(url, headers=headers, data=json.dumps(result_dict))
+        if not r.raise_for_status():
+            logger.debug('Sent result to TestObject: {}'.format(result))

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -38,6 +38,7 @@ class SauceLabs(object):
         self.client = sauceclient.SauceClient(username, access_key,)
 
     def send_result(self, session_id, name, result):
+        import pdb;pdb.set_trace()
         logger.debug('Sending result to SauceLabs')
         logger.debug('SauceOnDemandSessionID={} job-name={}'.format(session_id,
                                                                     name))


### PR DESCRIPTION
Initial PR that allows us to run tests on real devices via remote appium server (e.g. Sauce Labs Real Device Automation).

This PR expects a sauce_config.py module in base directory where your tests are ran, and it should include a `DEVICES` dictionary with capabilities to run your test. You will need to make sure `testobject_api_key` and `testobject_app_id` keys are set. These can be retrieved from https://app.testobject.com/#/yourusername/yourorg/appium/basic/instructions

@DramaFever/qa 