### PR TITLE
Add support for command line argument to specify platform configuration file

### DIFF
--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -57,6 +57,7 @@ from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import (
+    InvalidArgumentException,
     NoSuchAttributeException,
     NoSuchElementException,
     NoSuchFrameException,
@@ -1918,5 +1919,8 @@ def set_page_load_timeout(timeout):
     """Sets the maximum amount of time to wait for a page load to complete.
     :argument timeout: The amount of time to wait in seconds.
     """
-    _test.browser.set_page_load_timeout(timeout)
-    logger.debug('Set page load timeout to {} seconds.'.format(timeout))
+    try:
+        _test.browser.set_page_load_timeout(timeout)
+        logger.debug('Set page load timeout to {} seconds.'.format(timeout))
+    except InvalidArgumentException, e:
+        logger.debug('Could not set page load timeout. \n {}'.format(e))

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -146,6 +146,10 @@ def get_remote_options():
                       help=('url to WebDriver endpoint '
                             '(eg: http://host:port/wd/hub), '
                             'when using a remote Selenium RC'))
+    parser.add_option('--platform_config', dest='platform_config',
+                      default=None,
+                      help=('path to platform configuration file '
+                            'when using a remote client'))
     return parser
 
 

--- a/src/sst/config.py
+++ b/src/sst/config.py
@@ -54,6 +54,7 @@ shared_directory = None
 results_directory = None
 api_test_results = None
 api_client = None
+platform_config = None
 flags = []
 __args__ = {}
 cache = {}

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -171,11 +171,15 @@ def post_api_test_results():
         logger.debug("Could not send test results \n" + str(e))
 
 def find_client_credentials(module):
-    cwd = os.getcwd()
-    mod_path = os.path.join(cwd, '{}.py'.format(module))
-    if not os.path.isfile(mod_path):
-        mod_path = os.path.join(os.path.dirname(cwd), '{}.py'.format(module))
-    return imp.load_source(module, os.path.abspath(mod_path))
+    if config.platform_config:
+        path = os.path.realpath(config.platform_config)
+        return imp.load_source(os.path.basename(path), path)
+    else:
+        cwd = os.getcwd()
+        mod_path = os.path.join(cwd, '{}.py'.format(module))
+        if not os.path.isfile(mod_path):
+            mod_path = os.path.join(os.path.dirname(cwd), '{}.py'.format(module))
+        return imp.load_source(module, os.path.abspath(mod_path))
 
 def set_client_credentials(client):
     if client == 'testrail':

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -172,8 +172,9 @@ def post_api_test_results():
 
 def find_client_credentials(module):
     if config.platform_config:
-        path = os.path.realpath(config.platform_config)
-        return imp.load_source(os.path.basename(path), path)
+        mod_path = os.path.realpath(config.platform_config)
+        module = os.path.basename(mod_path).strip('.py')
+        return imp.load_source(module, mod_path)
     else:
         cwd = os.getcwd()
         mod_path = os.path.join(cwd, '{}.py'.format(module))

--- a/src/sst/scripts/remote.py
+++ b/src/sst/scripts/remote.py
@@ -42,6 +42,9 @@ def main():
     if cmd_opts.api_test_results:
         config.api_test_results = cmd_opts.api_test_results
 
+    if cmd_opts.platform_config:
+        config.platform_config = cmd_opts.platform_config
+
     browser_factory = browsers.RemoteBrowserFactory(
         {
             "browserName": cmd_opts.browser_type.lower(),


### PR DESCRIPTION
Currently if we execute tests remotely on SauceLabs, the framework looks for a single `sauce_config.py` file. This existing functionality is still supported, and I added support for a new command line option to allow the SauceLabs platform configuration file to be specified by the user. This means we can run different subsets of tests against different platform configurations without having to constantly edit the single configuration file.

I also added some exception handling in the set_page_load_timeout method to account for an issue in older versions of the FirefoxDriver: https://bugzilla.redhat.com/show_bug.cgi?id=1629909