### PR TITLE
Fix find_client_credentials for non SauceLabs configs

### DIFF
--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -171,7 +171,7 @@ def post_api_test_results():
         logger.debug("Could not send test results \n" + str(e))
 
 def find_client_credentials(module):
-    if config.platform_config:
+    if module == 'sauce_config' and config.platform_config:
         mod_path = os.path.realpath(config.platform_config)
         module = os.path.basename(mod_path).strip('.py')
         return imp.load_source(module, mod_path)


### PR DESCRIPTION
Recent changes broke the integration with TestRail if you are also running the tests specifying the `--platform-config` path. This fix allows you to use both the `-t` and `--platform-config` options as intended.