### PR TITLE
Allow Firefox browser to play DRM video

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -284,6 +284,7 @@ class FirefoxFactory(BrowserFactory):
 
     def setup_for_test(self, test):
         profile = webdriver.FirefoxProfile()
+        profile.set_preference('media.gmp-manager.updateEnabled', True)
         profile.set_preference('intl.accept_languages', 'en')
         profile.set_preference('browser.download.folderList', 1)
         profile.set_preference('browser.download.manager.showWhenStarting', False)


### PR DESCRIPTION
Local test runs were failing in Firefox on any tests that try to play video. This fix sets the media plugins update to True instead of hanging on the plugin install.

<img width="1358" alt="Screen Shot 2019-10-01 at 10 09 04 AM" src="https://user-images.githubusercontent.com/1066522/65973494-6cbb6500-e439-11e9-9a75-a200280bb456.png">


To test:
1. Download the latest version of geckodriver: https://github.com/mozilla/geckodriver/releases
2. Extract, and move geckodriver to /usr/local/bin
3. Execute `sst-run` with any video test using `-b Firefox`