### PR TITLE
Pass firefoxOptions to remote webdriver capabilities

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -113,6 +113,9 @@ class RemoteBrowserFactory(BrowserFactory):
             if 'chromeOptions' in test.context:
                 self.capabilities.update({
                         'chromeOptions': test.context['chromeOptions']})
+            elif 'moz:firefoxOptions' in test.context:
+                self.capabilities.update({
+                    'moz:firefoxOptions': test.context['moz:firefoxOptions']})
 
         elif self.webdriver_class == appium.webdriver.Remote:
             self.capabilities = {


### PR DESCRIPTION
Similar to our ability to specify chrome options during remote browser execution, we want to do the same for the Firefox browser to set the desired capabilities.