### PR TITLE
Fix results of multiple browser versions being logged to the same run ID

### DIFF
--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -110,8 +110,9 @@ def runtests(test_regexps, results_directory, out,
                                        browser[browser_name],
                                        browser['platformVersion'])
                 test_run = client.create_test_run(ids, platform_string)
-                logger.debug('Cases in current run ({}:{}): {}'.format(
+                logger.debug('Cases in current run ({} {}:{}): {}'.format(
                               browser[browser_name],
+                              browser['version'],
                               test_run['run_id'],
                               ids))
                 for test in alltests._tests:

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -115,7 +115,7 @@ def runtests(test_regexps, results_directory, out,
                               test_run['run_id'],
                               ids))
                 for test in alltests._tests:
-                    if browser[browser_name] in test.context[browser_name]:
+                    if browser == test.context:
                         test.run_id = test_run['run_id']
             logger.debug('Created test runs {} using the above cases'
                          .format(client.runs))


### PR DESCRIPTION
When running a test suite against multiple versions of the same browser, the results were all being sent to the same run ID. Instead of just comparing the browser name, we should look for the full platform config to identify the correct existing run for logging results.

To test, use `sst-remote` to run a directory of tests against a platform config containing multiple versions of the same browser, and ensure the TestRail plan has the results logged to the proper runs, instead of sending multiple results to the same run.