### PR TITLE
Pin setuptools version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytz==2013.7
 enum34==1.1.6
 urllib3==1.24.3
 python-dateutil
+setuptools==41.6.0


### PR DESCRIPTION
Support the git+git package format in requirement.txt and fix the following error when building sst
```
'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "'+git://g'"
```