### PR TITLE
Fix remote runs for web

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -81,15 +81,15 @@ class RemoteBrowserFactory(BrowserFactory):
             from sst import runtests
             self.creds = runtests.set_client_credentials('saucelabs')
             try:
-                self.browsers = self.creds.CAPABILITIES
-                apibase = None
-
                 if 'APPIUM_URL' in dir(self.creds):
+                    self.browsers = self.creds.CAPABILITIES
                     self.remote_url = self.creds.APPIUM_URL
                     self.webdriver_class = appium.webdriver.Remote
                     apibase = self.creds.API_BASE
                 else:
+                    self.browsers = self.creds.BROWSERS
                     self.remote_url = self.creds.URL
+                    apibase = None
 
                 self.remote_client = SauceLabs(self.creds.USERNAME,
                                                self.creds.ACCESS_KEY,

--- a/src/sst/loaders.py
+++ b/src/sst/loaders.py
@@ -216,8 +216,13 @@ class SSTestLoader(TestLoader):
         else:
             if self.browser_factory.remote_client:
                 for browser in self.browser_factory.browsers:
-                    test = self.loadTestFromScript(dir_name,
-                                                   script_name)
+                    if 'app' in browser:
+                        test = self.loadTestFromScript(dir_name,
+                                                       script_name)
+                    else:
+                        test = self.loadTestFromScript(dir_name,
+                                                       script_name,
+                                                       browser)
                     suite.addTest(test)
             else:
                 test = self.loadTestFromScript(dir_name, script_name)


### PR DESCRIPTION
Some of the recent changes to support Appium on Sauce Labs caused our web Sauce Labs tests to not be able to run anymore. This should make sure the browser configurations are properly pulled from the config file as well as setting the browser in the test context for web.

@babybunnytoto  can you please verify that we can still run the Android tests against Sauce Labs with these changes?