### PR TITLE
Add support for git dependencies in requirements.txt for both pip and setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,10 @@ LICENSE = 'Apache'
 readme = os.path.join(this_dir, 'README')
 LONG_DESCRIPTION = '\n%s' % open(readme).read()
 
-requirements = os.path.join(this_dir, 'requirements.txt')
-REQUIREMENTS = filter(None, open(requirements).read().splitlines())
+requirements_file = os.path.join(this_dir, 'requirements.txt')
+requirements = filter(None, open(requirements_file).read().splitlines())
+REQUIREMENTS = [req for req in requirements if 'git+git' not in req]
+REQUIREMENTS.append('sauceclient==1.0.1')
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -71,6 +73,7 @@ params = dict(
     package_data={'browsermob-proxy-2.1.2': ['browsermob-proxy-2.1.2/*']},
     include_package_data=True,
     install_requires=REQUIREMENTS,
+    dependency_links=['git+https://github.com/cgoldberg/sauceclient@aa27b7d#egg=sauceclient-1.0.1'],
 
     # metadata for upload to PyPI
     author=AUTHOR,


### PR DESCRIPTION
When installing dependencies from requirements.txt via setup that contain a link from github, we need to ensure that we provide the egg and package version and install as a dependency_link, so that the correct version is install from github, instead of through pypi.

This maintains support for installing requirements.txt via pip as well.