### PR TITLE
Fix the sending of test name and result to Sauce Labs for remote web jobs

### DIFF
--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -94,6 +94,7 @@ class SSTTestCase(testtools.TestCase):
             self.addCleanup(self.post_api_test_result)
         if self.browser_factory.remote_client:
             self.remote_client = self.browser_factory.remote_client
+            self.update_remote_job()
             self.addCleanup(self.post_remote_result)
         if self.screenshots_on:
             self.addOnException(self.take_screenshot_and_page_dump)
@@ -208,6 +209,10 @@ class SSTTestCase(testtools.TestCase):
                     'comment': comment}
         logger.debug("Could not find case_id for {}".format(self.id()))
         return None
+
+    def update_remote_job(self):
+        self.remote_client.update_job(session_id=self.browser.session_id,
+                                      name = self.id())
 
     def post_remote_result(self):
         result = False if self.getDetails() else True

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -45,7 +45,7 @@ class SauceLabs(object):
         logger.debug('Sending result to SauceLabs')
         logger.debug('SauceOnDemandSessionID={} job-name={}'.format(session_id,
                                                                     name))
-        if 'testobject' in self.api_base:
+        if self.api_base and 'testobject' in self.api_base:
             self.send_result_testobject(session_id, result)
         else:
             self.client.jobs.update_job(job_id=session_id, name=name,

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -41,6 +41,10 @@ class SauceLabs(object):
             self.api_base = apibase
         self.client = sauceclient.SauceClient(username, access_key, apibase)
 
+    def update_job(self, session_id, name):
+        if not self.api_base:
+            self.client.jobs.update_job(job_id=session_id, name=name)
+
     def send_result(self, session_id, name, result):
         logger.debug('Sending result to SauceLabs')
         logger.debug('SauceOnDemandSessionID={} job-name={}'.format(session_id,


### PR DESCRIPTION
The send_results functionality broke for remote web runs when we added the enhancements for test object. This fixes the updating of jobs and also sends the test name to the remote job as soon as the test starts instead of waiting until we send results at teardown.

To test: Run a test against Sauce Labs. You should see the test name updated for the job (instead of "Unnamed job 75256213a6a0.....") at the start of the test, and the passed/failed result of the test should be updated at the completion of the test (instead of showing the question mark).