### PR TITLE
Set Appium Sauce Labs testobject_test_name

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -126,6 +126,7 @@ class RemoteBrowserFactory(BrowserFactory):
 
         elif self.webdriver_class == appium.webdriver.Remote:
             self.capabilities = self.creds.CAPABILITIES[0]
+            self.capabilities['testobject_test_name'] = test.id().strip('.py')
 
         logger.debug('Remote capabilities set: {}'.format(self.capabilities))
 

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -126,7 +126,7 @@ class RemoteBrowserFactory(BrowserFactory):
 
         elif self.webdriver_class == appium.webdriver.Remote:
             self.capabilities = self.creds.CAPABILITIES[0]
-            self.capabilities['testobject_test_name'] = test.id().strip('.py')
+            self.capabilities['testobject_test_name'] = test.id()
 
         logger.debug('Remote capabilities set: {}'.format(self.capabilities))
 


### PR DESCRIPTION
Set the proper test name when running Appium tests on Sauce Labs instead of hardcoding in the test project sauce_config.py file.