### PR TITLE
Fix error when running Appium tests remotely and logging results to Test Rail

### DIFF
--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -17,6 +17,7 @@
 #   limitations under the License.
 #
 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import json
 import logging
 import requests
@@ -24,6 +25,7 @@ import sauceclient
 
 logger = logging.getLogger('SST')
 
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 class SauceLabs(object):
     """Helper class for creating an instance of sauceclient and posting results.

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -98,21 +98,24 @@ def runtests(test_regexps, results_directory, out,
             for browser in browser_factory.browsers:
                 tests = [t.case_id for t in alltests._tests if t.case_id]
                 ids = list(OrderedDict.fromkeys(tests))
-                try:
-                    browser_name = 'browserName'
-                    platform_string = '{} - {} - {}'.format(
-                                       browser['platform'],
-                                       browser[browser_name],
-                                       browser['version'])
-                except KeyError:
-                    browser_name = 'deviceName'
-                    platform_string = '{} - {}'.format(
-                                       browser[browser_name],
-                                       browser['platformVersion'])
+                # web
+                if 'browserName' in browser.keys():
+                    platform = 'platform'
+                    version = 'version'
+                    name = 'browserName'
+                # app
+                else:
+                    platform = 'platformName'
+                    version = 'platformVersion'
+                    name = 'deviceName'
+                platform_string = '{} - {} - {}'.format(
+                    browser[platform],
+                    browser[name],
+                    browser[version])
                 test_run = client.create_test_run(ids, platform_string)
                 logger.debug('Cases in current run ({} {}:{}): {}'.format(
-                              browser[browser_name],
-                              browser['version'],
+                              browser[name],
+                              browser[version],
                               test_run['run_id'],
                               ids))
                 for test in alltests._tests:


### PR DESCRIPTION
Fixing a KeyError due to the platform config differences between web and apps. This will let us run Appium tests on Sauce Labs with the TestRail -t flag

@babybunnytoto 